### PR TITLE
fix(release): use npm pack for tarball format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,16 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Pack dist tarball
+      - name: Pack
         run: |
-          assets="dist package.json package-lock.json README.md"
-          [ -f LICENSE ] && assets="$assets LICENSE"
-          tar -czf "trufi-gtfs-builder-${GITHUB_REF_NAME}.tgz" $assets
+          # npm pack produces a tarball with the npm-standard `package/` root,
+          # so the asset is consumable as a direct npm dependency:
+          #   "trufi-gtfs-builder": "https://.../trufi-gtfs-builder-vX.Y.Z.tgz"
+          # The package.json version stays at 2.1.0 by repo convention — the
+          # git tag is the real version. Rename the output to match the tag
+          # so the asset URL is predictable.
+          npm pack
+          mv trufi-gtfs-builder-*.tgz "trufi-gtfs-builder-${GITHUB_REF_NAME}.tgz"
 
       - name: Create Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
The v2.12.0 release tarball was unusable as an npm dependency because I used a manual `tar -czf` instead of `npm pack`. npm expects all package contents under a `package/` directory at the tarball root; my flat tarball put `dist/`, `package.json`, etc. at the top, so `npm install <url>.tgz` failed with `ENOENT: no such file or directory, open '.../package.json'`.

This switches the release workflow to `npm pack`, which produces the proper layout. Renamed the output to match the git tag for a predictable asset URL — `npm pack` uses the `package.json` version (`2.1.0` by repo convention), and consumers want `trufi-gtfs-builder-v<tag>.tgz`.

## Verification
Locally:
```
$ npm pack
trufi-gtfs-builder-2.1.0.tgz
$ tar tzf trufi-gtfs-builder-2.1.0.tgz | head -3
package/dist/geojson_to_trufi_tp_data/bus_route.js
package/dist/utils/customStopsLoader.js
package/dist/example.js
```

Installed as a `file:./trufi-gtfs-builder-2.1.0.tgz` dependency in a scratch project: `node_modules/trufi-gtfs-builder/dist/index.js` resolves cleanly. ✓

## After merge
- Tag `v2.12.1` → release workflow produces a working tarball at `https://github.com/trufi-association/trufi-gtfs-builder/releases/download/v2.12.1/trufi-gtfs-builder-v2.12.1.tgz`
- (Optional) Switch trufi-app/tools/gtfs-bolivia-cochabamba dep from `github:...#v2.12.0` (git URL) to the tarball URL — faster install, no clone+build step.