### PR TITLE
feat(overpass): allow configurable host so callers can swap mirrors

### DIFF
--- a/src/osm_to_geojson/osm_getter/overpass_downloader.ts
+++ b/src/osm_to_geojson/osm_getter/overpass_downloader.ts
@@ -1,10 +1,20 @@
 import * as https from 'https';
 import type { Bounds, OSMRelation, OSMWay, OSMNode, IOSMDataGetter } from '../../types';
 
+export interface OSMOverpassDownloaderOptions {
+  /**
+   * Overpass API host (without protocol or path). Defaults to
+   * `www.overpass-api.de`. Use this to point at a mirror when the default
+   * is overloaded — e.g. `overpass.kumi.systems`, `overpass.osm.ch`.
+   */
+  host?: string;
+}
+
 export default class OSMOverpassDownloader implements IOSMDataGetter {
   bbox: string;
+  host: string;
 
-  constructor(bounds: Bounds) {
+  constructor(bounds: Bounds, options: OSMOverpassDownloaderOptions = {}) {
     if (!bounds) {
       throw new Error('Missing bounds');
     }
@@ -18,6 +28,7 @@ export default class OSMOverpassDownloader implements IOSMDataGetter {
     }
 
     this.bbox = `${bounds.south},${bounds.west},${bounds.north},${bounds.east}`;
+    this.host = options.host ?? 'www.overpass-api.de';
   }
 
   overpassRequest = async (query: string, retries = 3): Promise<any> => {
@@ -43,7 +54,7 @@ export default class OSMOverpassDownloader implements IOSMDataGetter {
       const request = https.request(
         {
           method: 'POST',
-          host: 'www.overpass-api.de',
+          host: this.host,
           path: '/api/interpreter',
           headers: {
             'Content-Type': 'application/x-www-form-urlencoded',


### PR DESCRIPTION
## Summary

- `OSMOverpassDownloader` is currently hard-coded to `www.overpass-api.de`, which intermittently returns 504 on larger bboxes (e.g. the Cochabamba feed under `examples/Bolivia-Cochabamba`).
- This PR adds an optional second constructor argument so callers can point at a working mirror without having to subclass or monkey-patch private methods.
- Default stays `www.overpass-api.de` — no behavior change for existing callers.

## Usage

```ts
import { OSMOverpassDownloader } from 'trufi-gtfs-builder';

// unchanged — still hits www.overpass-api.de
new OSMOverpassDownloader(bounds);

// or use a mirror when the default is overloaded
new OSMOverpassDownloader(bounds, { host: 'overpass.kumi.systems' });
```

## Test plan

- [x] `npm run build` passes (clean tsc)
- [x] No-arg signature still compiles (existing examples in `src/example.ts` and `examples/Bolivia-Cochabamba/index.ts` are untouched)
- [ ] Smoke test against `overpass.kumi.systems` from a real consumer